### PR TITLE
enable to preprocess before preview and import, and store some results to the "global" context

### DIFF
--- a/src/Import/RowVisitor/PreprocessableRowVisitorInterface.php
+++ b/src/Import/RowVisitor/PreprocessableRowVisitorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ttskch\Bulkony\Import\RowVisitor;
+
+interface PreprocessableRowVisitorInterface extends RowVisitorInterface
+{
+    /**
+     * @param array<string> $csvRow
+     */
+    public function preprocess(array $csvRow, int $csvLineNumber, Context $context): void;
+}

--- a/tests/Fake/RowVisitor/PreprocessableRowVisitor.php
+++ b/tests/Fake/RowVisitor/PreprocessableRowVisitor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ttskch\Bulkony\Tests\Fake\RowVisitor;
+
+use Ttskch\Bulkony\Import\RowVisitor\Context;
+use Ttskch\Bulkony\Import\RowVisitor\PreprocessableRowVisitorInterface;
+
+class PreprocessableRowVisitor extends RowVisitor implements PreprocessableRowVisitorInterface
+{
+    public function preprocess(array $csvRow, int $csvLineNumber, Context $context): void
+    {
+        $context['context'] = 'from preprocess';
+
+        echo sprintf("[preprocess] csv line %d: %s\n", $csvLineNumber, json_encode($csvRow, JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/tests/Fake/RowVisitor/RowVisitor.php
+++ b/tests/Fake/RowVisitor/RowVisitor.php
@@ -11,8 +11,8 @@ class RowVisitor implements RowVisitorInterface
 {
     public function import(array $csvRow, int $csvLineNumber, Context $context): void
     {
-        assert(is_string($context['from_validate_to_preview_and_import']) || is_null($context['from_validate_to_preview_and_import']));
+        assert(is_string($context['context']) || is_null($context['context']));
 
-        echo sprintf("[import] csv line %d: %s with '%s'\n", $csvLineNumber, json_encode($csvRow, JSON_UNESCAPED_UNICODE), strval($context['from_validate_to_preview_and_import']));
+        echo sprintf("[import] csv line %d: %s with '%s'\n", $csvLineNumber, json_encode($csvRow, JSON_UNESCAPED_UNICODE), strval($context['context']));
     }
 }

--- a/tests/Fake/RowVisitor/ValidatableRowVisitor.php
+++ b/tests/Fake/RowVisitor/ValidatableRowVisitor.php
@@ -19,7 +19,7 @@ class ValidatableRowVisitor extends RowVisitor implements ValidatableRowVisitorI
             $error->addMessage('Invalid email address');
         }
 
-        $context['from_validate_to_preview_and_import'] = 'context';
+        $context['context'] = 'from validation';
 
         echo sprintf("[validate] csv line %d: %s\n", $errorList->getCsvLineNumber(), json_encode($csvRow, JSON_UNESCAPED_UNICODE));
     }

--- a/tests/Import/ImporterTest.php
+++ b/tests/Import/ImporterTest.php
@@ -9,6 +9,7 @@ use Ttskch\Bulkony\Import\Importer;
 use Ttskch\Bulkony\Import\Preview\Cell;
 use Ttskch\Bulkony\Import\Preview\Row;
 use Ttskch\Bulkony\Tests\Fake\RowVisitor\AbortableValidatableRowVisitor;
+use Ttskch\Bulkony\Tests\Fake\RowVisitor\PreprocessableRowVisitor;
 use Ttskch\Bulkony\Tests\Fake\RowVisitor\PreviewableRowVisitor;
 use Ttskch\Bulkony\Tests\Fake\RowVisitor\RowVisitor;
 use Ttskch\Bulkony\Tests\Fake\RowVisitor\ValidatablePreviewableRowVisitor;
@@ -49,6 +50,25 @@ EOS;
         $this->assertEquals($expectedEchoed, $echoed);
     }
 
+    public function testWithPreprocess(): void
+    {
+        // preprocessale row visitor
+        $rowVisitor = new PreprocessableRowVisitor();
+
+        ob_start();
+        $this->importer->import($this->csvFilePath, $rowVisitor);
+        $echoed = trim(strval(ob_get_clean()));
+        $expectedEchoed = <<<EOS
+[preprocess] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"}
+[preprocess] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
+[preprocess] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"}
+[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'from preprocess'
+[import] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"} with 'from preprocess'
+[import] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"} with 'from preprocess'
+EOS;
+        $this->assertEquals($expectedEchoed, $echoed);
+    }
+
     public function testWithValidatableRowVisitor(): void
     {
         // validatable row visitor
@@ -59,11 +79,11 @@ EOS;
         $echoed = trim(strval(ob_get_clean()));
         $expectedEchoed = <<<EOS
 [validate] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"}
-[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'context'
+[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'from validation'
 [validate] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 [onError] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 [validate] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"}
-[import] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"} with 'context'
+[import] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"} with 'from validation'
 EOS;
         $this->assertEquals($expectedEchoed, $echoed);
     }
@@ -78,7 +98,7 @@ EOS;
         $echoed = trim(strval(ob_get_clean()));
         $expectedEchoed = <<<EOS
 [validate] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"}
-[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'context'
+[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'from validation'
 [validate] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 [onError] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 EOS;
@@ -193,11 +213,11 @@ EOS2;
         $echoed = trim(strval(ob_get_clean()));
         $expectedEchoed = <<<EOS3
 [validate] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"}
-[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'context'
+[import] csv line 2: {"id":"1","name":"alice","email":"alice@example.com"} with 'from validation'
 [validate] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 [onError] csv line 3: {"id":"2","name":"bob","email":"bob@example.com"}
 [validate] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"}
-[import] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"} with 'context'
+[import] csv line 4: {"id":"3","name":"charlie","email":"charlie@example.com"} with 'from validation'
 EOS3;
         $this->assertEquals($expectedEchoed, $echoed);
     }


### PR DESCRIPTION
### What's changed

- Changed `Context` to a global one shared between importer methods.
- Enable to preprocess before preview and import, and store some results to the global `Context`